### PR TITLE
Add mail import model

### DIFF
--- a/core/mail_imports/models/__init__.py
+++ b/core/mail_imports/models/__init__.py
@@ -1,0 +1,1 @@
+from .mail_import import MailImport

--- a/core/mail_imports/models/mail_import.py
+++ b/core/mail_imports/models/mail_import.py
@@ -1,1 +1,21 @@
-# TODO: mail import model here
+"""
+This file contains the model for the mail import.
+"""
+
+from uuid import uuid4
+
+from django.db import models
+
+
+class MailImport(models.Model):
+    """
+    This is the db model for mail import.
+    """
+
+    uuid = models.UUIDField(db_index=True, default=uuid4, unique=True)
+    sender = models.CharField(max_length=255, blank=False)
+    bcc = models.CharField(max_length=255, blank=True)
+    subject = models.CharField(max_length=255, blank=True)
+    content = models.TextField(max_length=255, blank=True)
+    sending_datetime = models.DateTimeField(auto_now_add=True)
+    is_read = models.BooleanField(default=False)

--- a/core/migrations/0093_add_mail_import.py
+++ b/core/migrations/0093_add_mail_import.py
@@ -1,0 +1,42 @@
+# This file adds the migration for the mail import
+
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    This class adds the mail import
+    """
+
+    dependencies = [
+        ("core", "0092_remove_encryptedrecordmessage_message_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="MailImport",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "uuid",
+                    models.UUIDField(db_index=True, default=uuid.uuid4, unique=True),
+                ),
+                ("sender", models.CharField(max_length=255)),
+                ("bcc", models.CharField(blank=True, max_length=255)),
+                ("subject", models.CharField(blank=True, max_length=255)),
+                ("content", models.TextField(blank=True, max_length=255)),
+                ("sending_datetime", models.DateTimeField(auto_now_add=True)),
+                ("is_read", models.BooleanField(default=False)),
+            ],
+        ),
+    ]


### PR DESCRIPTION
This PR adds the model for mail import. This includes the model file and the migration file. I decided on the following fields as I thought they were relevant for storing mails:

- subject
- content of the mail
- email of sender
- timestamp of when the mail has been send
- boolean field whether the mail has been read or not (I can't remember if this was also relevant in the backend)

@danielmoessner Please let me know if I didn't add something that was expected to be in this PR, if you have any comments on missing fields, or if you see any room for improvement. 

For quality check I used pylint as linter, black as formatter and isort to sort my imports