### PR TITLE
577: Add user selection for articles

### DIFF
--- a/core/internal/api/articles.py
+++ b/core/internal/api/articles.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.db.models import Q, QuerySet
+from django.db.models import Q
 from django.utils import timezone
 
 from core.auth.models import OrgUser
@@ -13,26 +13,11 @@ from . import schemas
 router = Router()
 
 
-def add_orgs_to_articles(articles: QuerySet[Article]) -> list[OutputArticleList]:
-    return [
-        OutputArticleList(
-            id=article.pk,
-            title=article.title,
-            preview=article.preview,
-            date=article.date,
-        )
-        for article in articles
-    ]
-
-
 @router.get("", output_schema=list[schemas.OutputArticleList])
-def query_articles() -> list[OutputArticleList]:
-    articles = Article.objects.all()
+def query_articles(org_user: OrgUser) -> list[OutputArticleList]:
+    articles = Article.objects.filter(recipients=org_user.org).distinct()
 
-    if not articles:
-        return []
-
-    return add_orgs_to_articles(articles)
+    return [OutputArticleList.model_validate(article) for article in articles]
 
 
 @router.get("dashboard/", output_schema=list[OutputArticleList])
@@ -43,7 +28,4 @@ def latest_articles(org_user: OrgUser) -> list[OutputArticleList]:
         & (Q(recipients__isnull=True) | Q(recipients=org_user.org))
     ).distinct()
 
-    if not articles:
-        return []
-
-    return add_orgs_to_articles(articles)
+    return [OutputArticleList.model_validate(article) for article in articles]

--- a/core/internal/tests/test_articles.py
+++ b/core/internal/tests/test_articles.py
@@ -1,0 +1,64 @@
+import pytest
+from django.test import Client
+from django.utils import timezone
+
+from core.internal.models import Article
+from core.org.models import Org
+from core.tests import test_helpers
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def neighbourhood_user():
+    org = Org.objects.create(name="Neighbourhood RLC")
+    return test_helpers.create_org_user(org=org, email="neighbour@law-orga.de")
+
+
+@pytest.fixture
+def dummy_user():
+    org = Org.objects.create(name="Dummy RLC")
+    return test_helpers.create_org_user(org=org, email="dummy@law-orga.de")
+
+
+def make_article(title, *recipient_orgs):
+    article = Article.objects.create(
+        title=title,
+        preview="Preview",
+        date=timezone.now().date(),
+        content="Content",
+    )
+    if recipient_orgs:
+        article.recipients.set(recipient_orgs)
+    return article
+
+
+def visible_article_ids(user):
+    client = Client()
+    client.login(**user)
+    response = client.get("/api/internal/articles/dashboard/")
+    return {article["id"] for article in response.json()}
+
+
+def test_article_for_all_is_visible_to_all(neighbourhood_user, dummy_user):
+    article = make_article("For All", neighbourhood_user["org"], dummy_user["org"])
+    assert article.pk in visible_article_ids(neighbourhood_user)
+    assert article.pk in visible_article_ids(dummy_user)
+
+
+def test_article_for_nobody_is_visible_to_all(neighbourhood_user, dummy_user):
+    article = make_article("For Nobody")
+    assert article.pk in visible_article_ids(neighbourhood_user)
+    assert article.pk in visible_article_ids(dummy_user)
+
+
+def test_article_for_neighbourhood_only(neighbourhood_user, dummy_user):
+    article = make_article("For Neighbourhood", neighbourhood_user["org"])
+    assert article.pk in visible_article_ids(neighbourhood_user)
+    assert article.pk not in visible_article_ids(dummy_user)
+
+
+def test_article_for_dummy_only(neighbourhood_user, dummy_user):
+    article = make_article("For Dummy", dummy_user["org"])
+    assert article.pk not in visible_article_ids(neighbourhood_user)
+    assert article.pk in visible_article_ids(dummy_user)


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR is the second attempt to show news articles only to selected users. I think that this time it works better, because the filtering is done before we send the information to the API. That way we don't have to change anything in the frontend. Also I think this time the code is more minimal, but still does what we want it to do. 


### Proposed Changes

<!-- Describe this PR in more detail. -->

- Send news only to selected users

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #577 
