### PR TITLE
575: Add activity state for users

### DIFF
--- a/core/auth/api/org_user.py
+++ b/core/auth/api/org_user.py
@@ -42,6 +42,7 @@ class OutputOrgUserSmall(BaseModel):
     is_active: bool
     last_login_month: Optional[str]
     qualifications: list[str]
+    activity_state: str
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/core/auth/models/org_user.py
+++ b/core/auth/models/org_user.py
@@ -138,7 +138,6 @@ class OrgUser(models.Model):
     old_private_key = models.BinaryField(null=True)
     is_private_key_encrypted = models.BooleanField(default=False)
     old_public_key = models.BinaryField(null=True)
-    # activity
     last_activity = models.DateTimeField(null=True, blank=True)
     # other
     created = models.DateTimeField(auto_now_add=True)

--- a/core/auth/models/org_user.py
+++ b/core/auth/models/org_user.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -16,6 +17,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import send_mail
 from django.db import models
 from django.template import loader
+from django.utils import timezone
 
 from core.auth.domain.user_key import UserKey
 from core.auth.token_generator import EmailConfirmationTokenGenerator
@@ -136,6 +138,8 @@ class OrgUser(models.Model):
     old_private_key = models.BinaryField(null=True)
     is_private_key_encrypted = models.BooleanField(default=False)
     old_public_key = models.BinaryField(null=True)
+    # activity
+    last_activity = models.DateTimeField(null=True, blank=True)
     # other
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
@@ -181,6 +185,18 @@ class OrgUser(models.Model):
     @property
     def last_login_month(self):
         return self.user.last_login_month
+
+    @property
+    def activity_state(self) -> str:
+        now = timezone.now()
+        if self.last_activity:
+            if self.last_activity >= now - timedelta(days=90):
+                return "green"
+            if self.last_activity >= now - timedelta(days=180):
+                return "yellow"
+        if self.user.last_login and self.user.last_login >= now - timedelta(days=365):
+            return "orange"
+        return "red"
 
     @property
     def user_key(self) -> KeyOfUser:

--- a/core/injections.py
+++ b/core/injections.py
@@ -1,3 +1,7 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
 from core.auth.domain.user_key import UserKey
 from core.auth.models.org_user import OrgUser
 from core.auth.models.user import UserProfile
@@ -59,6 +63,20 @@ def log_usecase(context: CallbackContext):
         )
 
 
+def update_last_activity(context: CallbackContext):
+    if not context.success:
+        return
+    if not isinstance(context.actor, OrgUser):
+        return
+    now = timezone.now()
+    one_hour_ago = now - timedelta(hours=1)
+    if (
+        context.actor.last_activity is None
+        or context.actor.last_activity < one_hour_ago
+    ):
+        OrgUser.objects.filter(pk=context.actor.pk).update(last_activity=now)
+
+
 def get_key(__actor: OrgUser) -> UserKey:
     # injecting the UserKey only works if the usecase itself
     # already has OrgUser as an actor
@@ -82,4 +100,5 @@ INJECTIONS = {
 CALLBACKS = [
     handle_events,
     log_usecase,
+    update_last_activity,
 ]

--- a/core/migrations/0163_orguser_last_activity.py
+++ b/core/migrations/0163_orguser_last_activity.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0162_rename_article_description_to_preview"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="orguser",
+            name="last_activity",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/core/org/api/query.py
+++ b/core/org/api/query.py
@@ -40,6 +40,7 @@ class OutputMember(BaseModel):
     id: int
     name: str
     email: str
+    activity_state: str
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR adds the activity state to the user

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add a field for the last activity to the model for the org_user (and a migration)
- Add a callback to fill in the last activity (if it hasn't happened in the last hour)
- Send back an activity state that depends on the last activity or the login

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Open http://localhost:4205/api/auth/org_users/ and see the new field activity_state there.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #575 
