### PR TITLE
Return ID of new data sheet after creation

### DIFF
--- a/core/command.py
+++ b/core/command.py
@@ -8,6 +8,7 @@ from django.http import (
     HttpResponseBadRequest,
     HttpResponseNotAllowed,
     HttpResponseNotFound,
+    JsonResponse,
 )
 from django.utils.module_loading import import_string
 from pydantic import ValidationError
@@ -115,5 +116,8 @@ def django_command(request: HttpRequest) -> HttpResponse:
     command_result = handle_error(command_fn)
     if isinstance(command_result, HttpResponse):
         return command_result
+
+    if isinstance(command_result, dict):
+        return JsonResponse(command_result)
 
     return HttpResponse()

--- a/core/data_sheets/models/template.py
+++ b/core/data_sheets/models/template.py
@@ -48,6 +48,7 @@ class DataSheetTemplate(models.Model):
     updated = models.DateTimeField(auto_now=True)
 
     if TYPE_CHECKING:
+        id: int
         org_id: int
         org: models.ForeignKey[Org]  # type: ignore[no-redef]
         records: models.QuerySet[DataSheet]

--- a/core/data_sheets/use_cases/templates.py
+++ b/core/data_sheets/use_cases/templates.py
@@ -24,9 +24,10 @@ from core.seedwork.use_case_layer import UseCaseError, use_case
 
 
 @use_case(permissions=[PERMISSION_ADMIN_MANAGE_RECORD_TEMPLATES])
-def create_template(__actor: OrgUser, name: str):
+def create_template(__actor: OrgUser, name: str) -> dict[str, int]:
     template = DataSheetTemplate.create(name=name, org=__actor.org)
     template.save()
+    return {"id": template.id}
 
 
 @use_case(permissions=[PERMISSION_ADMIN_MANAGE_RECORD_TEMPLATES])


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR starts returning the ID of a new data sheet after a call to create said data sheet. That is in order to immediately show the new data sheet after creation in the Admin in the frontend.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- There might be confusion in other create cases where we probably don't immediately open the newly created thing.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to frontend branch `573-Refactoring-datasheet-templates`, go into the Admin > Data Sheets, create a new one, see that you are immediately sent to the newly created data sheet.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->
Part of https://github.com/lawandorga/lawandorga-main-frontend/issues/573
