### PR TITLE
642: Add new badge for notes and tasks

### DIFF
--- a/core/auth/models/user.py
+++ b/core/auth/models/user.py
@@ -28,6 +28,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     name = models.CharField(max_length=255)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
+    previous_login = models.DateTimeField(null=True, blank=True)
 
     # custom manager
     objects = UserProfileManager()

--- a/core/auth/views/mfa.py
+++ b/core/auth/views/mfa.py
@@ -114,5 +114,9 @@ class MfaLoginView(RedirectURLMixin, generic.FormView):
         )
 
     def form_valid(self, form):
-        login(self.request, form.get_user())
+        user = form.get_user()
+        previous_login = user.last_login
+        login(self.request, user)
+        user.previous_login = previous_login
+        user.save(update_fields=["previous_login"])
         return HttpResponseRedirect(self.get_success_url())

--- a/core/auth/views/user.py
+++ b/core/auth/views/user.py
@@ -54,6 +54,7 @@ class CustomLoginView(LoginView):
 
     def form_valid(self, form):
         user: UserProfile = form.get_user()  # type: ignore
+        previous_login = user.last_login
 
         if hasattr(user, "org_user"):
             run_user_login_checks(user, form.data["password"])
@@ -78,7 +79,10 @@ class CustomLoginView(LoginView):
                 url += f"?next={next_param}"
             return HttpResponseRedirect(url)
 
-        return super().form_valid(form)
+        response = super().form_valid(form)
+        user.previous_login = previous_login
+        user.save(update_fields=["previous_login"])
+        return response
 
 
 class CustomLogoutView(LogoutView):

--- a/core/migrations/0168_userprofile_previous_login.py
+++ b/core/migrations/0168_userprofile_previous_login.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "core",
+            "0167_remove_calendareventshare_calendar_share_exactly_one_principal_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userprofile",
+            name="previous_login",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/core/org/api/query.py
+++ b/core/org/api/query.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from uuid import UUID
 
+from django.db.models import BooleanField, ExpressionWrapper, Q
 from pydantic import BaseModel, ConfigDict
 
 from core.auth.models import OrgUser
@@ -14,6 +15,7 @@ class OutputNote(BaseModel):
     note: str
     is_wide: bool
     order: int
+    is_new: bool
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -99,7 +101,13 @@ def query__list_groups(org_user: OrgUser):
 
 @router.get(url="notes/", output_schema=list[OutputNote])
 def query__list_notes(org_user: OrgUser):
-    notes = Note.objects.filter(org__id=org_user.org_id)
+    previous_login = org_user.user.previous_login
+    notes = Note.objects.filter(org__id=org_user.org_id).annotate(
+        is_new=ExpressionWrapper(
+            Q(created__gt=previous_login) if previous_login else Q(pk__isnull=True),
+            output_field=BooleanField(),
+        )
+    )
     return list(notes)
 
 

--- a/core/tasks/api/query.py
+++ b/core/tasks/api/query.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Optional
 from uuid import UUID
 
-from django.db.models import Q
+from django.db.models import BooleanField, ExpressionWrapper, Q
 from pydantic import BaseModel, ConfigDict
 
 from core.auth.models import OrgUser
@@ -26,6 +26,7 @@ class OutputTask(BaseModel):
     progress: int
     priority: str
     is_done: bool
+    is_new: bool
     comments: list[Any]
     tags_as_list: list[str]
     deadline: Optional[datetime]
@@ -43,5 +44,19 @@ router = Router()
     output_schema=list[OutputTask],
 )
 def query__tasks(org_user: OrgUser):
-    tasks = Task.objects.filter(Q(creator=org_user) | Q(assignees=org_user)).distinct()
+    previous_login = org_user.user.previous_login
+    tasks = (
+        Task.objects.filter(Q(creator=org_user) | Q(assignees=org_user))
+        .distinct()
+        .annotate(
+            is_new=ExpressionWrapper(
+                (
+                    Q(created_at__gt=previous_login)
+                    if previous_login
+                    else Q(pk__isnull=True)
+                ),
+                output_field=BooleanField(),
+            )
+        )
+    )
     return tasks


### PR DESCRIPTION
### Short Description
<!-- Describe this PR in one or two sentences. -->
This PR adds the fields `is_new` to notes and tasks. This is a prerequisite to add a `New` badge.

### Proposed Changes
<!-- Describe this PR in more detail. -->

- `is_new` field to notes
- `is_new` field to tasks

### Side Effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing
<!-- List all things that should be tested while reviewing this PR. -->
Check in the [API](http://localhost:4205/api/tasks/query/) if the field is_new appears for notes and tasks. You could also do some additional tests by adding new notes and tasks and then make sure, that the field is true for these notes and tasks.

### Resolved Issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #642 
