### PR TITLE
Use simple staticfiles storage in test settings

### DIFF
--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -33,3 +33,8 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 # Static Files
 # https://docs.djangoproject.com/en/dev/howto/static-files/
 MEDIA_ROOT = os.path.join(BASE_DIR, "tmp/media/testing/")
+
+# Static files
+# Tests render templates without running collectstatic, so avoid manifest-based
+# staticfiles storage in the test settings.
+STORAGES["staticfiles"]["BACKEND"] = "django.contrib.staticfiles.storage.StaticFilesStorage"


### PR DESCRIPTION
## Summary

Updates the Django test settings to use simple static file storage during tests.

The base settings use WhiteNoise's `CompressedManifestStaticFilesStorage`, which expects a collected staticfiles manifest. During pytest runs, templates that reference `logo256blue.png` failed while rendering because the manifest entry was missing.

This change keeps the production/base staticfiles storage untouched and only overrides `STORAGES["staticfiles"]["BACKEND"]` in `config/settings/testing.py`.

## Problem observed

Before this change, `uv run pytest` failed with repeated errors like:

`ValueError: Missing staticfiles manifest entry for 'logo256blue.png'`

Several auth/page-rendering tests failed for the same underlying reason.

## Validation

Targeted auth tests:

`uv run pytest core/auth/tests/test_mfa.py core/auth/tests/test_password_reset.py core/auth/tests/test_register.py core/auth/tests/test_user.py`

Result:

`21 passed`

Full test suite:

`uv run pytest`

Result:

`438 passed`

## Related issue

Fixes #605.
