### PR TITLE
Chore: Add task_id to task comments

### DIFF
--- a/core/tasks/use_cases/task.py
+++ b/core/tasks/use_cases/task.py
@@ -94,6 +94,7 @@ def add_comment(
     task = task_from_uuid(__actor, task_id)
     task.comments = task.comments + [
         {
+            "task_id": str(task_id),
             "email": __actor.email,
             "name": __actor.name,
             "date": timezone.now().isoformat(),


### PR DESCRIPTION
### Short Description
<!-- Describe this PR in one or two sentences. -->
This PR adds the uuid of tasks to it's comment. This is needed for [#653](https://github.com/lawandorga/lawandorga-main-frontend/pull/659) in the frontend, where we don't want to use the index of an array to map the comments, but something more stable.

### Proposed Changes
<!-- Describe this PR in more detail. -->

- Add task_id to array

### Side Effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None are intended

### Testing
<!-- List all things that should be tested while reviewing this PR. -->

- Create a new comment to an existing task. See in the Django admin that it has a task_id. Then go to the endpoint in the api `api/tasks/query/` and check that it exists there too


### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -
