### PR TITLE
Refactor `comment_id`

### DIFF
--- a/core/tasks/tests/test_task.py
+++ b/core/tasks/tests/test_task.py
@@ -256,6 +256,8 @@ def test_update_task_comments(db):
     assert isinstance(task.comments[0]["date"], str)
     assert task.comments[0]["date"]
     assert task.comments[0]["comment"] == "First comment"
+    assert isinstance(task.comments[0]["comment_id"], str)
+    assert task.comments[0]["comment_id"]
 
     add_comment(assignee, task_id=task.uuid, comment="Second comment")
     task.refresh_from_db()
@@ -265,6 +267,9 @@ def test_update_task_comments(db):
     assert isinstance(task.comments[1]["date"], str)
     assert task.comments[1]["date"]
     assert task.comments[1]["comment"] == "Second comment"
+    assert isinstance(task.comments[1]["comment_id"], str)
+    assert task.comments[1]["comment_id"]
+    assert task.comments[0]["comment_id"] != task.comments[1]["comment_id"]
 
 
 def test_delete_task(db):

--- a/core/tasks/use_cases/task.py
+++ b/core/tasks/use_cases/task.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import bleach
 from django.utils import timezone
@@ -94,10 +94,10 @@ def add_comment(
     task = task_from_uuid(__actor, task_id)
     task.comments = task.comments + [
         {
-            "task_id": str(task_id),
             "email": __actor.email,
             "name": __actor.name,
             "date": timezone.now().isoformat(),
+            "comment_id": uuid4(),
             "comment": comment,
         }
     ]


### PR DESCRIPTION
### Short Description
<!-- Describe this PR in one or two sentences. -->
This PR refactors the comments for tasks to include a comment_id instead of a task_id.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Generate a comment_id and show it instead of the task_id

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

- The comment_id should be shown in the API instead of a task_id

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -
