### PR TITLE
Fix: Fix `comment_id` by converting to string

### DIFF
--- a/core/tasks/use_cases/task.py
+++ b/core/tasks/use_cases/task.py
@@ -97,7 +97,7 @@ def add_comment(
             "email": __actor.email,
             "name": __actor.name,
             "date": timezone.now().isoformat(),
-            "comment_id": uuid4(),
+            "comment_id": str(uuid4()),
             "comment": comment,
         }
     ]


### PR DESCRIPTION
### Short Description
<!-- Describe this PR in one or two sentences. -->
This PR converts the comment_id to a string, effectively fixing the error we get when adding a comment to the task

### Proposed Changes
<!-- Describe this PR in more detail. -->

- Convert comment_id to str

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -
